### PR TITLE
removed annoying noautoread

### DIFF
--- a/plugin/phprefactor.vim
+++ b/plugin/phprefactor.vim
@@ -108,7 +108,5 @@ func! PhpRefactorRunCommand(refactoring, args)
 
     exec command .' | '.g:php_refactor_patch_command
 
-    setlocal noautoread
-
     exec ':redraw!'
 endfunc


### PR DESCRIPTION
The plugin should respect the user's setting - if he has set `autoread` in his config don't override it.